### PR TITLE
Support optional positional and keyword parameters

### DIFF
--- a/lib/mimic/controls/subject/named_parameters.rb
+++ b/lib/mimic/controls/subject/named_parameters.rb
@@ -3,7 +3,7 @@ module Mimic
     module Subject
       module NamedParameters
         class Example
-          def some_method(some_parameter:, some_other_parameter:)
+          def some_method(some_parameter:, some_other_parameter: nil)
           end
         end
       end

--- a/lib/mimic/controls/subject/positional_parameters.rb
+++ b/lib/mimic/controls/subject/positional_parameters.rb
@@ -3,7 +3,7 @@ module Mimic
     module Subject
       module PositionalParameters
         class Example
-          def some_method(some_parameter, some_other_parameter)
+          def some_method(some_parameter, some_other_parameter=nil)
           end
         end
       end

--- a/lib/mimic/define_methods.rb
+++ b/lib/mimic/define_methods.rb
@@ -46,8 +46,12 @@ module Mimic
       name = parameter.fetch(1) { :args }
 
       case type
+      when :opt
+        return "#{name}=nil"
       when :req
         return "#{name}"
+      when :key
+        return "#{name}: nil"
       when :keyreq
         return "#{name}:"
       when :rest


### PR DESCRIPTION
Allows `Mimic::DefineMethods` to mimic methods that contain optional parameters.

Reviewed https://github.com/ruby/ruby/blob/5c276e1cc91c5ab2a41fbf7827af2fed914a2bc0/spec/ruby/core/method/parameters_spec.rb to confirm that `.parameter_signature` now recognizes all parameter types covered by the Ruby automated tests.