### PR TITLE
Mutation of string literal is fixed

### DIFF
--- a/lib/mimic/define_methods.rb
+++ b/lib/mimic/define_methods.rb
@@ -32,7 +32,7 @@ module Mimic
     end
 
     def self.parameter_list(parameters)
-      parameter_list = ''
+      parameter_list = String.new
       parameters.each do |parameter|
         parameter_signature = parameter_signature(parameter)
         parameter_list << "#{parameter_signature}, "


### PR DESCRIPTION
Since ruby 2.3 the core team developers have intended to freeze string literals to reduce unnecessary string allocations as strings allocated from string literals are rarely mutated and therefore could be stored frozen and normalized in global memory - similar to symbols.  

In ruby 3.4 deprecation warnings were added when strings allocated from literals in source code were mutated.

To make a string mutable there are two options, the first is by using the String constructor (i.e. `String.new("some-value")`) and the second is via the use of `String#dup` (i.e. `'some-value'.dup`).

Some strategies that are recommended to avoid unintended mutation of string literals are:
- Enabling deprecation warnings with the `-W:deprecated` ruby command line option
- Adding `Warning[:deprecated] = true` to initialization files such as `test_init.rb`
- Adding a `# frozen_string_literal: true` comment to the start of every source code file

To aid in finding string literal mutations ruby 3.4 introduces the `--debug-frozen-string-literal` option which, when the deprecation warning is written, will also print the line where the mutated string literal was defined.